### PR TITLE
chore(feature) add api key to db request

### DIFF
--- a/app/api/log/route.ts
+++ b/app/api/log/route.ts
@@ -32,7 +32,8 @@ export async function POST(req: Request): Promise<Response> {
   const record = await pb.collection('searches').create({
     "query": searchQuery?.query,
     "result": answer,
-    "links": searchQuery?.sourceLinks
+    "links": searchQuery?.sourceLinks,
+    "db_access_key": process.env.DB_ACCESS_KEY
   });
 
   if(!record.ok) {

--- a/environment.d.ts
+++ b/environment.d.ts
@@ -6,6 +6,7 @@ declare global {
       OPENAI_MODEL: string;
       DB_STORE: boolean;
       DB_URL: string;
+      DB_ACCESS_KEY: string;
     }
   }
 }


### PR DESCRIPTION
This means that the application doesn't have to authenticate with Pocketbase. Instead custom rule uses an api_key set in the application `.env` file.